### PR TITLE
Zlk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-output/*/*.*
+outputs/*/*.*
 *.log
 
 *.csv

--- a/configuration.yml
+++ b/configuration.yml
@@ -3,7 +3,7 @@ regions:
   plk:
     name: Plzeňský kraj
     url: https://dotace.plzensky-kraj.cz/verejnost/zadosti?_name=Zadosti&_search=false&nd=1742109491719&rows=25&page=1&sidx=&sord=asc, https://dotace.plzensky-kraj.cz/verejnost/individualni-zadosti?_name=IndividualniZadosti&_search=false&nd=1742131019737&rows=25&page=1&sidx=&sord=asc
-    process: 0
+    process: 1
   zlk:
     name: Zlínský kraj
     process: 1

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,34 @@
+import unittest
+import sys
+
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from src.library.uitilities import rewrite_url
+
+
+class TestRewriteUrl(unittest.TestCase):
+    def test_rewrite_url_with_new_query(self):
+        url = "http://example.com/path?param1=value1&param2=value2"
+        new_query = {"param3": "value3", "param4": "value4"}
+        expected_url = "http://example.com/path?param1=value1&param2=value2&param3=value3&param4=value4"
+        result = rewrite_url(url, new_query)
+        self.assertEqual(result, expected_url)
+
+    def test_rewrite_url_without_new_query(self):
+        url = "http://example.com/path?param1=value1&param2=value2"
+        expected_url = "http://example.com/path?param1=value1&param2=value2"
+        result = rewrite_url(url)
+        self.assertEqual(result, expected_url)
+        
+    def test_rewrite_url_in_cls_zlk_region_context(self):
+        url = "https://zlinskykraj.cz/archiv-dotaci?f-year=2021"
+        new_query = {'f-year':2023,'page':10}
+        expected_url = "https://zlinskykraj.cz/archiv-dotaci?f-year=2023&page=10"
+        result = rewrite_url(url, new_query)
+        self.assertEqual(result, expected_url)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Changes:
- src/libriary/regions/cls_zlk_region.py
- src/library/utilities.py

Moves moves method rewrite_url from src/libriary/regions/cls_zlk_region.py to src/library/utilities.py. The reason is to make this method more universal and more accesible across the project.