### PR TITLE
Fixes usage of rewrite_url in cls_zlk_region.

### DIFF
--- a/src/library/regions/cls_zlk_region.py
+++ b/src/library/regions/cls_zlk_region.py
@@ -77,7 +77,7 @@ class ZlkRegion(AbstractRegion):
             post_event('processing_year',{'module':__name__,'data':{'data':year}})
           
             # Builing new url, finding first page for currently prcessed year.
-            new_url = rewrite_url(url,{'f-year':year,'page':1})
+            new_url = rewrite_url(url, new_query= {'f-year':year,'page':1})
             post_event('processing_page',{'module':__name__,'data':{'data':str(1)}})
             # Fetching content and processing in by BS.
             content = get_html_content(new_url)
@@ -122,7 +122,7 @@ class ZlkRegion(AbstractRegion):
                 # and concatenate it with all data.
                 for i in range (2,pages_count+1):
                     post_event('processing_page',{'module':__name__,'data':{'data':str(i)}})
-                    new_url = rewrite_url(url,{'f-year':year,'page':i})
+                    new_url = rewrite_url(url, new_query={'f-year':year,'page':i})
 
                     data = self._get_appeals_list(content)
                     df_tmp = pd.DataFrame.from_records(data,columns=headers)

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,7 +13,7 @@ class TestRewriteUrl(unittest.TestCase):
         url = "http://example.com/path?param1=value1&param2=value2"
         new_query = {"param3": "value3", "param4": "value4"}
         expected_url = "http://example.com/path?param1=value1&param2=value2&param3=value3&param4=value4"
-        result = rewrite_url(url, new_query)
+        result = rewrite_url(url,new_query= new_query)
         self.assertEqual(result, expected_url)
 
     def test_rewrite_url_without_new_query(self):
@@ -26,7 +26,31 @@ class TestRewriteUrl(unittest.TestCase):
         url = "https://zlinskykraj.cz/archiv-dotaci?f-year=2021"
         new_query = {'f-year':2023,'page':10}
         expected_url = "https://zlinskykraj.cz/archiv-dotaci?f-year=2023&page=10"
-        result = rewrite_url(url, new_query)
+        result = rewrite_url(url, new_query= new_query)
+        self.assertEqual(result, expected_url)
+        
+    def test_rewrite_url_new_scheme(self):
+        url = "http://example.com/path?param1=value1&param2=value2"
+        expected_url = "https://example.com/path?param1=value1&param2=value2"
+        result = rewrite_url(url, new_scheme="https")
+        self.assertEqual(result, expected_url)
+        
+    def test_rewrite_url_new_netloc(self):
+        url = "http://example.com/path?param1=value1&param2=value2"
+        expected_url = "http://newdomain.com/path?param1=value1&param2=value2"
+        result = rewrite_url(url, new_netloc="newdomain.com")
+        self.assertEqual(result, expected_url)
+        
+    def test_rewrite_url_new_path(self):
+        url = "http://example.com/path?param1=value1&param2=value2"
+        expected_url = "http://example.com/newpath?param1=value1&param2=value2"
+        result = rewrite_url(url, new_path="/newpath")
+        self.assertEqual(result, expected_url)
+        
+    def test_rewrite_url_new_fragment(self):
+        url = "http://example.com/path?param1=value1&param2=value2#oldfragment"
+        expected_url = "http://example.com/path?param1=value1&param2=value2#newfragment"
+        result = rewrite_url(url, new_fragment="newfragment")
         self.assertEqual(result, expected_url)
 
 


### PR DESCRIPTION
Fixes usage of rewrite_url in cls_zlk_region.py. It's necessary to use named params.